### PR TITLE
Feat: Added All Projects option to Transaction History card and made projects a dependency in useEffect on the Profile page

### DIFF
--- a/app/[locale]/profile/page.js
+++ b/app/[locale]/profile/page.js
@@ -32,7 +32,7 @@ const Page = () => {
       setUsersProjects(projectWithUser);
       setIsLoading(false);
     }
-  }, []);
+  }, [projects]); // added projects as a dependency so that it runs whenever 'projects' changes. 
 
   let oneProjectInfo = null;
 

--- a/app/components/cards/TransactionHistory.jsx
+++ b/app/components/cards/TransactionHistory.jsx
@@ -27,12 +27,17 @@ export default function TransactionHistory({ oneProjectInfo, usersProjects }) {
 
   useEffect(() => {
     if (!loading) {
-      const filteredDonations = donations.filter(
-        (donation) => donation.projectId === selectedProject
+      let filteredDonations = donations.filter((donation) =>
+        usersProjects.some((project) => project.id === donation.projectId)
       );
+      if (selectedProject) {
+        filteredDonations = filteredDonations.filter(
+          (donation) => donation.projectId === selectedProject
+        );
+      }
       setDonate(filteredDonations);
     }
-  }, [donations, selectedProject, loading]);
+  }, [donations, selectedProject, loading, usersProjects]);
 
   const handleProjectSelect = (projectId) => {
     setSelectedProject(projectId);
@@ -102,6 +107,9 @@ export default function TransactionHistory({ oneProjectInfo, usersProjects }) {
                           </Typography>
                         </MenuHandler>
                         <MenuList {...triggers}>
+                          <MenuItem onClick={() => handleProjectSelect("")}>
+                            All projects
+                          </MenuItem>
                           {usersProjects.map((project) => (
                             <MenuItem
                               key={project?.id}


### PR DESCRIPTION
In this PR, I added a new feature to the Transaction History card, which allows users to view transactions for all their projects. Additionally, I modified the Profile page's useEffect hook to run whenever there are changes in the 'projects' data, ensuring that the user's projects are displayed correctly on the page. 

![Ekran Resmi 2023-07-20 16 55 09](https://github.com/202303-PRM-TR-FEW/team-10/assets/127213973/f662a403-a67e-45db-96b9-0953cf0cd9ca)
